### PR TITLE
Auto-shutdown wget and duplicate files fixes

### DIFF
--- a/scripts/install-autoshutdown-extension/on-jupyter-server-start.sh
+++ b/scripts/install-autoshutdown-extension/on-jupyter-server-start.sh
@@ -4,8 +4,11 @@
 set -eux
 
 sudo yum -y install wget
-wget https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension/raw/main/sagemaker_studio_autoshutdown-0.1.1.tar.gz
-pip install sagemaker_studio_autoshutdown-0.1.1.tar.gz
+
+# Saving the tarball to a file or folder with a '.' prefix will prevent it from cluttering up users' file tree views:
+mkdir -p .auto-shutdown
+wget -O .auto-shutdown/extension.tar.gz https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension/raw/main/sagemaker_studio_autoshutdown-0.1.1.tar.gz
+pip install .auto-shutdown/extension.tar.gz
 jlpm config set cache-folder /tmp/yarncache
 jupyter lab build --debug --minimize=False
 


### PR DESCRIPTION
**Issue #, if available:** #2, #3

**Description of changes:**

- Install missing wget dependency in server-only example.
- Overwrite same local tarball location each start-up (instead of producing extra unused files).
- Move user home dir assets to a hidden '.'-prefixed folder to avoid cluttering the workspace in UI for users (and discourage unexpected user modification of the timeouts, particularly in the server-only case!)

**Testing done:**

Checked both scripts work okay and set up the extension in a test domain (`ap-northeast-1`, internet access enabled)

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
