### PR TITLE
fix(autoshutdown): kernel AioClientCreator issue

### DIFF
--- a/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
+++ b/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
@@ -49,12 +49,12 @@ wget -O .auto-shutdown/extension.tar.gz https://github.com/aws-samples/sagemaker
 # aws s3 --endpoint-url [S3 Interface Endpoint] cp s3://[tarball location] .
 
 # Installs the extension
-cd .auto-shutdown
-tar xzf extension.tar.gz
-cd sagemaker_studio_autoshutdown-0.1.1
-pip install pydeps/*
-pip install --no-dependencies --no-build-isolation -e .
-jupyter serverextension enable --py sagemaker_studio_autoshutdown
+pip install .auto-shutdown/extension.tar.gz
+jupyter labextension disable sagemaker-studio-autoshutdown  # Disable the UI component
+jlpm config set cache-folder /tmp/yarncache
+jupyter lab build --debug --minimize=False
+
+jupyter serverextension enable --py sagemaker_studio_autoshutdown  # Enable the back-end component
 
 # Restarts the jupyter server
 nohup supervisorctl -c /etc/supervisor/conf.d/supervisord.conf restart jupyterlabserver

--- a/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
+++ b/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
@@ -49,12 +49,11 @@ wget -O .auto-shutdown/extension.tar.gz https://github.com/aws-samples/sagemaker
 # aws s3 --endpoint-url [S3 Interface Endpoint] cp s3://[tarball location] .
 
 # Installs the extension
-pip install .auto-shutdown/extension.tar.gz
-jupyter labextension disable sagemaker-studio-autoshutdown  # Disable the UI component
-jlpm config set cache-folder /tmp/yarncache
-jupyter lab build --debug --minimize=False
-
-jupyter serverextension enable --py sagemaker_studio_autoshutdown  # Enable the back-end component
+cd .auto-shutdown
+tar xzf extension.tar.gz
+cd sagemaker_studio_autoshutdown-0.1.1
+pip install --no-dependencies --no-build-isolation -e .
+jupyter serverextension enable --py sagemaker_studio_autoshutdown
 
 # Restarts the jupyter server
 nohup supervisorctl -c /etc/supervisor/conf.d/supervisord.conf restart jupyterlabserver


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

A possible fix for observed kernel start failures after using the no-UI autoshutdown widget sample: Instead of partially installing the package to disable the extension UI, fully install it but disable the UI.

This is not ideal because the result is that the full extension UI is installed but de-activated (e.g. if users enabled and then opened the extension manager they could potentially find and enable the auto-shutdown settings UI) - but seems to solve the error and I think doesn't materially change the likelihood of users finding & disabling/editing the settings? It also has the nice consequence that we're not trying to hack around partially installing the package.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
