### PR TITLE
Changed the way to convert script to base64

### DIFF
--- a/add-lcc-script.sh
+++ b/add-lcc-script.sh
@@ -8,7 +8,7 @@ export SCRIPT_FILE_NAME='scripts/set-proxy-settings/on-jupyter-server-start.sh'
 export SCRIPT_TYPE="JupyterServer"
 # export SCRIPT_TYPE="KernelGateway"
 
-export LCC_CONTENT=`cat ${SCRIPT_FILE_NAME} | base64`
+export LCC_CONTENT=`openssl base64 -A -in $SCRIPT_FILE_NAME`
 
 aws sagemaker --region us-east-2 create-studio-lifecycle-config \
   --studio-lifecycle-config-name $LCC_SCRIPT_NAME \


### PR DESCRIPTION
Changed base64 converting to avoid new white spaces in LCC_CONTENT variable to avoid white space in --studio-lifecycle-config-content $LCC_CONTENT which result in a error.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
