### PR TITLE
replacing base64 generation

### DIFF
--- a/add-lcc-script.sh
+++ b/add-lcc-script.sh
@@ -8,7 +8,7 @@ export SCRIPT_FILE_NAME='scripts/set-proxy-settings/on-jupyter-server-start.sh'
 export SCRIPT_TYPE="JupyterServer"
 # export SCRIPT_TYPE="KernelGateway"
 
-export LCC_CONTENT=`cat ${SCRIPT_FILE_NAME} | base64`
+LCC_CONTENT=`openssl base64 -A -in ${SCRIPT_FILE_NAME}`
 
 aws sagemaker --region us-east-2 create-studio-lifecycle-config \
   --studio-lifecycle-config-name $LCC_SCRIPT_NAME \


### PR DESCRIPTION
replacing 
export LCC_CONTENT=`cat ${SCRIPT_FILE_NAME} | base64`
With:
LCC_CONTENT=`openssl base64 -A -in ${SCRIPT_FILE_NAME}`
As previous command was introducing whitespaces into the base64 string (tested on a SageMaker Studio notebook terminal).
Now it's also inline with the command suggested in the blog post: https://aws.amazon.com/blogs/machine-learning/customize-amazon-sagemaker-studio-using-lifecycle-configurations/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
