### PR TITLE
update s3 cp output location

### DIFF
--- a/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
+++ b/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
@@ -46,7 +46,7 @@ sudo yum install -y wget
 wget -O .auto-shutdown/extension.tar.gz https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension/raw/main/sagemaker_studio_autoshutdown-0.1.5.tar.gz
 
 # Or instead, could serve the tarball from an S3 bucket in which case "wget" would not be needed:
-# aws s3 --endpoint-url [S3 Interface Endpoint] cp s3://[tarball location] .
+# aws s3 --endpoint-url [S3 Interface Endpoint] cp s3://[tarball location] .auto-shutdown/extension.tar.gz
 
 # Installs the extension
 cd .auto-shutdown


### PR DESCRIPTION
*Issue #, if available:*
For installing auto shutdown server extension, the aws s3 cp link downloads the file in whatever name is stored in S3. However, the `tar` command expects the file to be named `extension.tar.gz`. 

*Description of changes:*
Updated the `aws cp` link to download to a specific file and location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
