### PR TITLE
Remove external dependency on `wget`

### DIFF
--- a/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
+++ b/scripts/install-autoshutdown-server-extension/on-jupyter-server-start.sh
@@ -40,10 +40,9 @@ else:
 EOF
 chmod +x .auto-shutdown/set-time-interval.sh
 
-# "wget" is not part of the base Jupyter Server image, you need to install it first if needed to download the tarball
-sudo yum install -y wget
 # You can download the tarball from GitHub or alternatively, if you're using VPCOnly mode, you can host on S3
-wget -O .auto-shutdown/extension.tar.gz https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension/raw/main/sagemaker_studio_autoshutdown-0.1.5.tar.gz
+curl -L https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension/raw/main/sagemaker_studio_autoshutdown-0.1.5.tar.gz --output .auto-shutdown/extension.tar.gz
+
 
 # Or instead, could serve the tarball from an S3 bucket in which case "wget" would not be needed:
 # aws s3 --endpoint-url [S3 Interface Endpoint] cp s3://[tarball location] .auto-shutdown/extension.tar.gz


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Swapped the use of `wget` for the Sagemaker images' built in `curl` binary to remove an external dependency (yum has proved an issue in some isolated environments).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
