### PR TITLE
proxy for git is added

### DIFF
--- a/scripts/set-proxy-settings/on-jupyter-server-start.sh
+++ b/scripts/set-proxy-settings/on-jupyter-server-start.sh
@@ -24,3 +24,5 @@ echo "import sys,os,os.path" | tee -a ~/.ipython/profile_default/startup/00-star
 echo "os.environ['HTTP_PROXY']="\""$PROXY_SERVER"\""" | tee -a ~/.ipython/profile_default/startup/00-startup.py >/dev/null
 echo "os.environ['HTTPS_PROXY']="\""$PROXY_SERVER"\""" | tee -a ~/.ipython/profile_default/startup/00-startup.py >/dev/null
 echo "os.environ['NO_PROXY']="\""$EXCLUDED_HOSTS"\""" | tee -a ~/.ipython/profile_default/startup/00-startup.py >/dev/null
+
+git config --global http.proxy "${PROXY_SERVER}"


### PR DESCRIPTION
Git plugin is ignoring env vars, meanwhile CLI works. Its required to set proxy for git in settings, otherwise jupiterlab pligin (UI git) would not work
