### PR TITLE
Remove hard-coded add-lcc-script region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# OS and IDE files:
+.DS_Store
+.idea
+.ipynb_checkpoints/
+.vscode/
+
+# Python build artifacts:
+__pycache__/

--- a/add-lcc-script.sh
+++ b/add-lcc-script.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 # Registers a Lifecycle Configuration Script using the AWS CLI
+# NOTE: This registration by itself will not attach or enable it for any domains/users yet
 
 set -eux
 
 export LCC_SCRIPT_NAME='set-proxy'
 export SCRIPT_FILE_NAME='scripts/set-proxy-settings/on-jupyter-server-start.sh'
-export SCRIPT_TYPE="JupyterServer"
-# export SCRIPT_TYPE="KernelGateway"
+export SCRIPT_TYPE='JupyterServer'
+# export SCRIPT_TYPE='KernelGateway'
 
 LCC_CONTENT=`openssl base64 -A -in ${SCRIPT_FILE_NAME}`
 
-aws sagemaker --region us-east-2 create-studio-lifecycle-config \
+aws sagemaker create-studio-lifecycle-config \
   --studio-lifecycle-config-name $LCC_SCRIPT_NAME \
   --studio-lifecycle-config-content $LCC_CONTENT \
   --studio-lifecycle-config-app-type $SCRIPT_TYPE


### PR DESCRIPTION
**Issue #, if available:** #32

**Description of changes:**

- Add a `.gitignore` to help avoid accidental check-in of OS/IDE temporary files
- Remove the hard-coded `us-east-2` region in the `add-lcc-script.sh` as mentioned by #32 
- Add a note to `add-lcc-script.sh` reminding users that adding the script alone doesn't configure it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
