### PR TITLE
fix: Pin bash-language-server in install-lsp-features

### DIFF
--- a/scripts/install-lsp-features/on-jupyter-server-start.sh
+++ b/scripts/install-lsp-features/on-jupyter-server-start.sh
@@ -31,7 +31,7 @@ pip install jupyterlab-lsp \
     jupyterlab-code-formatter black isort
 # Some LSP language servers install via JS, not Python. For full list of language servers see:
 # https://jupyterlab-lsp.readthedocs.io/en/latest/Language%20Servers.html
-jlpm add --dev bash-language-server dockerfile-language-server-nodejs
+jlpm add --dev bash-language-server@"<5.0.0" dockerfile-language-server-nodejs
 
 # This configuration override is optional, to make LSP "extra-helpful" by default:
 CMP_CONFIG_DIR=.jupyter/lab/user-settings/@krassowski/jupyterlab-lsp/


### PR DESCRIPTION
**Issue #, if available:** #34

**Description of changes:**

Pin install of bash-language-server below v5 because Studio currently uses NodeJS v14, which bash-language-server@5.0.0 dropped support for.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
